### PR TITLE
Disallow DOCTYPE element in SAML responses to prevent XXE vulnerabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 cache:
   directories:

--- a/src/main/java/com/coveo/saml/SamlClient.java
+++ b/src/main/java/com/coveo/saml/SamlClient.java
@@ -552,7 +552,6 @@ public class SamlClient {
             }
 
             try {
-              setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
               setFeature(XERCES_FEATURE_PREFIX + DISALLOW_DOCTYPE_DECL_FEATURE, true);
             } catch (Throwable ex) {
               throw new SamlException(

--- a/src/main/java/com/coveo/saml/SamlClient.java
+++ b/src/main/java/com/coveo/saml/SamlClient.java
@@ -40,7 +40,6 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -59,6 +58,9 @@ import javax.xml.bind.ValidationException;
 import javax.xml.namespace.QName;
 
 import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
+
+import static com.sun.org.apache.xerces.internal.impl.Constants.DISALLOW_DOCTYPE_DECL_FEATURE;
+import static com.sun.org.apache.xerces.internal.impl.Constants.XERCES_FEATURE_PREFIX;
 
 public class SamlClient {
   private static final Logger logger = LoggerFactory.getLogger(SamlClient.class);
@@ -547,6 +549,14 @@ public class SamlClient {
               throw new SamlException(
                   "Cannot disable comments parsing to mitigate https://www.kb.cert.org/vuls/id/475445",
                   ex);
+            }
+
+            try {
+              setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+              setFeature(XERCES_FEATURE_PREFIX + DISALLOW_DOCTYPE_DECL_FEATURE, true);
+            } catch (Throwable ex) {
+              throw new SamlException(
+                  "Cannot disable external entities to prevent XXE injection", ex);
             }
           }
         };

--- a/src/test/java/com/coveo/saml/SamlClientTest.java
+++ b/src/test/java/com/coveo/saml/SamlClientTest.java
@@ -217,4 +217,22 @@ public class SamlClientTest {
     SamlResponse response = client.decodeAndValidateSamlResponse(AN_ENCODED_RESPONSE);
     assertEquals("mlaporte@coveo.com", response.getNameID());
   }
+
+  // Test for https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+  @Test
+  public void itIsNotVulnerableToXXEAttacks() throws Throwable {
+    String decoded = new String(Base64.decodeBase64(AN_ENCODED_RESPONSE), StandardCharsets.UTF_8);
+    String withDtd = "<!DOCTYPE note SYSTEM \"Note.dtd\">" + decoded;
+    SamlClient client =
+        SamlClient.fromMetadata(
+            "myidentifier", "http://some/url", getXml("adfs.xml"), SamlClient.SamlIdpBinding.POST);
+    client.setDateTimeNow(ASSERTION_DATE);
+    try {
+      client.decodeAndValidateSamlResponse(
+          Base64.encodeBase64String(withDtd.getBytes(StandardCharsets.UTF_8)));
+      assertTrue(false);
+    } catch (SamlException ex) {
+      assertTrue(ex.getCause().toString().contains("DOCTYPE is disallowed"));
+    }
+  }
 }


### PR DESCRIPTION
Fixes #37 