### PR TITLE
Re introduced disabling of DTD to avoid XXE attacks

### DIFF
--- a/src/main/java/com/coveo/saml/SamlClient.java
+++ b/src/main/java/com/coveo/saml/SamlClient.java
@@ -441,6 +441,10 @@ public class SamlClient {
   private static BasicParserPool createDOMParser() throws SamlException {
     BasicParserPool basicParserPool = new BasicParserPool();
     try {
+      Map<String, Boolean> features = new HashMap<>();
+      features.put("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+      features.put("http://apache.org/xml/features/disallow-doctype-decl", true);
+      basicParserPool.setBuilderFeatures(features);
       basicParserPool.initialize();
     } catch (ComponentInitializationException e) {
       throw new SamlException("Failed to create an XML parser");


### PR DESCRIPTION
This was originally fixed a while ago but was lost in a subsequent change in XML parsers.

There was an existing test, but I added another based on the specific report we received. I also confirmed with a local full-loop test.

Note that the existing unit test for this was failing on master branch.