### PR TITLE
Bump common-collections from 3.2.1 to 3.2.2 to fix vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,12 +81,17 @@
       <artifactId>opensaml-saml-impl</artifactId>
       <version>${opensaml.version}</version>
     </dependency>
-    <!-- normally transitive via opensaml, bumped here
-         to address vulnerabilities -->
     <dependency>
+      <!-- transitive via opensaml, bumped here to address vulnerabilities -->
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
       <version>1.61</version>
+    </dependency>
+    <dependency>
+      <!-- transitive via opensaml, bumped here from 3.2.1 to 3.2.2 to address vulnerabilities. -->
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.2.2</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Snyk identified some vulnerabilities coming from `org.opensaml`. Here is the problematic path:

> org.opensaml:opensaml-saml-impl@3.4.3 › org.apache.velocity:velocity@1.7 › commons-collections:**commons-collections@3.2.1** 

We already use the latest version of `opensaml` ([3.4.3](https://mvnrepository.com/artifact/org.opensaml/opensaml-core)).

Downgrading `opensaml` in this case seems to cause more impact than changing the transitive dependency. Thus, I propose to bump the patch version of the transitive dependency `commons-collections` explicitly from `3.2.1` to `3.2.2`. 

I compared the two versions. The [release notes of 3.2.2](https://github.com/apache/commons-collections/compare/collections-3.2.1...collections-3.2.2#diff-a3d054590c32de57d87be233927e755dR12) says that it is mainly a release to fix bugs and security vulnerabilities. It even states:
> "All users are strongly encouraged to updated to this release."

The release notes does not mention any breaking changes.