### PR TITLE
Clean up for building with JDK11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.10.3</version>
+        <configuration>
+          <source>8</source>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/src/main/java/com/coveo/saml/SamlClient.java
+++ b/src/main/java/com/coveo/saml/SamlClient.java
@@ -696,7 +696,7 @@ public class SamlClient {
   /**
    * Remove all additional service provider decryption certificate/key pairs.
    */
-  public void clearAdditionalSPKeys() throws SamlException {
+  public void clearAdditionalSPKeys() {
     additionalSpCredentials = new ArrayList<>();
   }
 

--- a/src/test/java/com/coveo/saml/SamlClientTest.java
+++ b/src/test/java/com/coveo/saml/SamlClientTest.java
@@ -14,7 +14,6 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Collections;
 
 import org.apache.commons.codec.binary.Base64;
 import org.joda.time.DateTime;


### PR DESCRIPTION
Hi folks, I tried to run `mvn install` with my JDK11 environment:
```
Maven home: /usr/local/Cellar/maven/3.5.2/libexec
Java version: 11.0.7, vendor: AdoptOpenJDK
Java home: /Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home
Default locale: en_CA, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.6", arch: "x86_64", family: "mac"
```

and I got errors:

```
MavenReportException: Error while generating Javadoc: 
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
[ERROR] /Users/zhangmengxi/learning/saml-client/src/main/java/com/coveo/saml/SamlClient.java:699: warning: no @throws for com.coveo.saml.SamlException
[ERROR]   public void clearAdditionalSPKeys() throws SamlException {
```

and
```
MavenReportException: Error while generating Javadoc: 
Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.

Command line was: /Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/bin/javadoc @options @packages
```

My fix for them is on this PR~ Hope it helps~