### PR TITLE
v4.0.3 - Bump woodstox dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.coveo</groupId>
   <artifactId>saml-client</artifactId>
-  <version>4.0.2</version>
+  <version>4.0.3</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>
@@ -86,6 +86,12 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
       <version>1.67</version>
+    </dependency>
+    <dependency>
+      <!-- transitive via opensaml, bumped here to address vulnerabilities -->
+      <groupId>com.fasterxml.woodstox</groupId>
+      <artifactId>woodstox-core</artifactId>
+      <version>5.3.0</version>
     </dependency>
     <dependency>
       <!-- transitive via opensaml, bumped here from 3.2.1 to 3.2.2 to address vulnerabilities. -->


### PR DESCRIPTION
Bump woodstox dependency due to vuln, was not covered by bumping opensaml.