### PR TITLE
Bump commons-text to 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.9</version>
+      <version>1.10.0</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
CVE-2022-42889

Based on how commons-text is used here and that it appears only as a first order and not transitive dependency I don't think we are vulnerable but we may as well update.

https://www.infoq.com/news/2022/11/apache-commons-vulnerability/?utm_source=facebook&utm_medium=link&utm_campaign=calendar
